### PR TITLE
Address issue #14 by removing unused key lookup

### DIFF
--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -583,7 +583,9 @@ def _worker(data_type):
         while st < end:
             _query = data_query.execute()
 
-            lim = _query['limit']
+            # 'limit' key is not available on non-owner API keys
+            # and we are not currently breaking on this value below 
+            # lim = _query['limit']
             results = _query[dkey]
 
             for dt in results:


### PR DESCRIPTION
The problematic key lookup is only being used by code that had previously been commented out, so I've commented it out as well.

https://github.com/sofarocean/sofar-api-client-python/issues/14