### PR TITLE
Cleaned version of the baro/mic inclusion.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as file:
 
 setuptools.setup(
     name='pysofar',
-    version='0.1.11',
+    version='0.1.12',
     license='Apache 2 License',
     install_requires=[
         'requests',

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -333,7 +333,9 @@ class WaveDataQuery(SofarConnection):
             'includeFrequencyData': 'false',
             'includeDirectionalMoments': 'false',
             'includeSurfaceTempData': 'false',
-            'includeNonObs': 'false'
+            'includeNonObs': 'false',
+            'includeMicrophoneData': 'false',
+            'includeBarometerData': 'false'
         }
         if params is not None:
             self._params.update(params)
@@ -367,6 +369,20 @@ class WaveDataQuery(SofarConnection):
         """
         self._limit = value
         self._params.update({'limit': value})
+
+    def barometer(self, include: bool):
+        """
+
+        :param include: True if you want the query to include waves
+        """
+        self._params.update({'includeBarometerData': str(include).lower()})
+
+    def microphone(self, include: bool):
+        """
+
+        :param include: True if you want the query to include waves
+        """
+        self._params.update({'includeMicrophoneData': str(include).lower()})
 
     def waves(self, include: bool):
         """
@@ -471,16 +487,19 @@ class WaveDataQuery(SofarConnection):
             del self._params['endDate']
 
     def __str__(self):
-        s = f"Query for {self.spotter_id} \n" +\
-            f"  Start: {self.start_date or 'From Beginning'} \n" +\
-            f"  End: {self.end_date or 'Til Present'} \n" +\
-            "  Params:\n" +\
-            f"    id: {self._params['spotterId']}\n" +\
-            f"    limit: {self._params['limit']} \n" +\
-            f"    waves: {self._params['includeWaves']} \n" +\
-            f"    wind: {self._params['includeWindData']} \n" +\
-            f"    track: {self._params['includeTrack']} \n" +\
-            f"    frequency: {self._params['includeFrequencyData']} \n" +\
+        s = f"Query for {self.spotter_id} \n" + \
+            f"  Start: {self.start_date or 'From Beginning'} \n" + \
+            f"  End: {self.end_date or 'Til Present'} \n" + \
+            "  Params:\n" + \
+            f"    id: {self._params['spotterId']}\n" + \
+            f"    limit: {self._params['limit']} \n" + \
+            f"    waves: {self._params['includeWaves']} \n" + \
+            f"    wind: {self._params['includeWindData']} \n" + \
+            f"    barometer: {self._params['includeBarometerData']} \n" + \
+            f"    sst: {self._params['includeSurfaceTempData']} \n" + \
+            f"    microphone: {self._params['includeMicrophoneData']} \n" + \
+            f"    track: {self._params['includeTrack']} \n" + \
+            f"    frequency: {self._params['includeFrequencyData']} \n" + \
             f"    directional_moments: {self._params['includeDirectionalMoments']} \n"
 
         return s

--- a/src/pysofar/spotter.py
+++ b/src/pysofar/spotter.py
@@ -246,6 +246,8 @@ class Spotter:
                   include_track: bool = False, include_frequency_data: bool = False,
                   include_directional_moments: bool = False,
                   include_surface_temp_data: bool = False,
+                  include_barometer_data=False,
+                  include_microphone_data=False,
                   smooth_wave_data: bool = False,
                   smooth_sg_window: int = 135,
                   smooth_sg_order: int = 4,
@@ -268,6 +270,8 @@ class Spotter:
                                             returned to also include directional moments
         :param include_surface_temp_data: Defaults to False. Set to True if your device is a v2 model or newer with the
                                           SST sensor installed
+        :param include_barometer_data: Defaults to False. Set to True if your device is a v3 model or newer with the
+                                       barometer installed
 
         :return: Data as a json based on the given query paramters
         """
@@ -278,6 +282,8 @@ class Spotter:
         _query.frequency(include_frequency_data)
         _query.directional_moments(include_directional_moments)
         _query.surface_temp(include_surface_temp_data)
+        _query.barometer(include_barometer_data)
+        _query.microphone(include_microphone_data)
         _query.smooth_wave_data(smooth_wave_data)
         _query.smooth_sg_window(smooth_sg_window)
         _query.smooth_sg_order(smooth_sg_order)


### PR DESCRIPTION
This adapts the client to include barometer/pressure data in requests following the patterns already established in the code. Minimum working example (requires access to api and Spotter):

```python
from pysofar.spotter import Spotter

# You will need a valid access token setup for the pysofar library for this to
# work. We refer to the pysofar documentation how to set that up.
spotter = Spotter('SPOT-010149','SPOT-010149')

data = spotter.grab_data(limit=20,start_date='2021-03-22T00:00:00.000Z',end_date='2022-03-23T00:00:00.000Z',
                         include_wind=True,
                         include_barometer_data=True,
                         include_surface_temp_data=True,
                         include_microphone_data=True
                         )

print(data['barometerData'])
```

(Removed all linting from the previous pull)