### PR TITLE
F/search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as file:
 
 setuptools.setup(
     name='pysofar',
-    version='0.1.12',
+    version='0.1.13',
     license='Apache 2 License',
     install_requires=[
         'requests',

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -14,7 +14,7 @@ from multiprocessing.pool import ThreadPool
 from pysofar import SofarConnection
 from pysofar.tools import parse_date
 from pysofar.wavefleet_exceptions import QueryError, CouldNotRetrieveFile
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 import warnings
 
 
@@ -678,7 +678,7 @@ def _worker(data_type):
     return _helper
 
 
-def unpaginate( get_function, endpoint_suffix , params ):
+def unpaginate( get_function, endpoint_suffix , params )->Dict:
     """
     Generator function to unpaginate a paginated request.
 

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -14,6 +14,8 @@ from multiprocessing.pool import ThreadPool
 from pysofar import SofarConnection
 from pysofar.tools import parse_date
 from pysofar.wavefleet_exceptions import QueryError, CouldNotRetrieveFile
+from typing import List, Tuple
+import warnings
 
 
 class SofarApi(SofarConnection):
@@ -224,6 +226,48 @@ class SofarApi(SofarConnection):
         return self._get_all_data(['waves', 'wind', 'frequency', 'track'], start_date, end_date, params)
 
     def get_spotters(self): return get_and_update_spotters(_api=self)
+
+    def search(self, shape:str, shape_params:List[Tuple], start_date:str, end_date:str,
+               radius=None, page_size=100,return_generator=False):
+
+        if shape not in ('circle','envelope'):
+            raise TypeError('Shape needs to be one of type Circle or Envelope')
+
+        if page_size > 500:
+            warnings.warn('Maximum page size is 500')
+            page_size=500
+
+        if shape == 'circle' and radius is None:
+            raise ValueError('Radius needs to be set when shape is circle')
+
+        # flatten
+        if shape == 'envelope':
+            vertices = []
+            for point in shape_params:
+                vertices += point
+        elif shape == 'circle':
+            vertices = shape_params
+
+        params = {
+            'shape':shape,
+            # convert list to a comma seperated string of values. Requests does not
+            # like iterators as argument.
+            'shapeParams':','.join([str(x) for x in vertices]),
+            'startDate':start_date,
+            'endDate':end_date,
+            'pageSize':page_size,
+            'radius':radius
+        }
+        def get_function(endpoint_suffix,params ):
+            scode, data = self._get(endpoint_suffix, params=params)
+            if scode != 200:
+                raise QueryError(data['message'])
+            return data
+
+        if return_generator:
+            return unpaginate(get_function,'search',params)
+        else:
+            return list(unpaginate(get_function,'search',params))
 
     # ---------------------------------- Helper Functions -------------------------------------- #
     @property
@@ -632,3 +676,39 @@ def _worker(data_type):
         return query_data
 
     return _helper
+
+
+def unpaginate( get_function, endpoint_suffix , params ):
+    """
+    Generator function to unpaginate a paginated request.
+
+    Note:
+    It is a little ugly now with the removing of the endpoint prefix so that
+    the _get function can append it again. Right now it looks like the paginated
+    server returns http instead of https in the url so this may actually be a
+    good thing.
+
+    :param get_function: the _get fuction that takes an endpoint suffic and params as arguments
+    :param endpoint_suffix: endpoint to hit from the Sofar Api
+    :param params: dict of additional query parameters to write beyond default values
+
+    :return: track data as a list
+    """
+    suffix = endpoint_suffix
+    while True:
+        page = get_function( suffix, params)
+
+        for item in page['data']:
+            yield item
+
+        if page['metadata']['page']['hasMoreData']:
+            url = page['metadata']['page']['nextPage']
+            # here we remove the prefix, but keep everything else in the url
+            # returned by wavefleet.
+            suffix = endpoint_suffix + url.split(endpoint_suffix)[1]
+
+            # parameters are no longer needed as these are already encoded
+            # in the given url.
+            params = None
+        else:
+            break


### PR DESCRIPTION
This adds the search [endpoint](https://docs.sofarocean.com/spotter-and-smart-mooring/spotter-data/search)to pysofar. Sample use:

```
from pysofar.sofar import SofarApi
sofarapi = SofarApi()

# Define parameters (as documented)
shape_params = [(40,-60),(30,-50)]
shape = 'envelope'
start_date = '2022-06-01T00:00:00Z'
end_date = '2022-06-02T00:00:00Z'
page_size=100

# get the data
data = sofarapi.search(shape,shape_params,start_date,end_date,page_size=page_size)

```
Note that pagination is abstracted away from the user using a simple generator function. If desired, the generator can be retrieved explicitly, allowing for just in time downloading of data:
```
data = sofarapi.search(shape,shape_params,start_date,end_date,page_size=page_size,return_generator=True)

for spotter in data:
      ( do something with the spotter data)
```
 Returned data is just the raw json response translated to Python types.