### PR TITLE
Add support for includeSpikes flag in wave data API

### DIFF
--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -377,6 +377,7 @@ class WaveDataQuery(SofarConnection):
             'includeFrequencyData': 'false',
             'includeDirectionalMoments': 'false',
             'includeSurfaceTempData': 'false',
+            'includeSpikes': 'false',            
             'includeNonObs': 'false',
             'includeMicrophoneData': 'false',
             'includeBarometerData': 'false'
@@ -477,6 +478,13 @@ class WaveDataQuery(SofarConnection):
         :param include: True if you want the query to include surface temp data
         """
         self._params.update({'includeSurfaceTempData': str(include).lower()})
+
+    def spikes(self, include: bool):
+        """
+
+        :param include: True if you want the query to include data points exceeding our spike filter
+        """
+        self._params.update({'includeSpikes': str(include).lower()})
 
     def smooth_wave_data(self, include: bool):
         """

--- a/src/pysofar/spotter.py
+++ b/src/pysofar/spotter.py
@@ -246,8 +246,9 @@ class Spotter:
                   include_track: bool = False, include_frequency_data: bool = False,
                   include_directional_moments: bool = False,
                   include_surface_temp_data: bool = False,
-                  include_barometer_data=False,
-                  include_microphone_data=False,
+                  include_spikes: bool = False,
+                  include_barometer_data = False,
+                  include_microphone_data = False,
                   smooth_wave_data: bool = False,
                   smooth_sg_window: int = 135,
                   smooth_sg_order: int = 4,
@@ -272,6 +273,8 @@ class Spotter:
                                           SST sensor installed
         :param include_barometer_data: Defaults to False. Set to True if your device is a v3 model or newer with the
                                        barometer installed
+        :param include_spikes: Defaults to False. Set to True if you wish to include data points that our system has
+                                        identified as a potentially unwanted spike.
 
         :return: Data as a json based on the given query paramters
         """
@@ -282,6 +285,7 @@ class Spotter:
         _query.frequency(include_frequency_data)
         _query.directional_moments(include_directional_moments)
         _query.surface_temp(include_surface_temp_data)
+        _query.spikes(include_spikes)
         _query.barometer(include_barometer_data)
         _query.microphone(include_microphone_data)
         _query.smooth_wave_data(smooth_wave_data)


### PR DESCRIPTION
Some data points may be omitted without the `includeSpikes=true` flag, according to the following:

> We filter spikes in Peak period that exceed 30s, as these are almost always indications of mooring effects, or other motions not associated with wave motion (eg a unit being picked up by a boat)

> Usually a relatively small portion of the time domain data associated with a spectral ensemble is polluted by this type of noise, and we have a more sophisticated on-board time-domain filter in development