### PR TITLE
Update pysofar tests

### DIFF
--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -574,19 +574,20 @@ class WaveDataQuery(SofarConnection):
 
 
 # ---------------------------------- Util Functions -------------------------------------- #
-def get_and_update_spotters(_api=None):
+def get_and_update_spotters(_api=None, _processes=None):
     """
     :return: A list of the Spotter objects associated with this account
     """
     from itertools import repeat
 
     api = _api or SofarApi()
+    processes = _processes or 16
 
     # grab device id's and query for device data
     # initialize Spotter objects
     spot_data = api.devices
 
-    pool = ThreadPool(processes=16)
+    pool = ThreadPool(processes=processes)
     spotters = pool.starmap(_spot_worker, zip(spot_data, repeat(api)))
     pool.close()
 

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -595,7 +595,7 @@ def get_and_update_spotters(_api=None, _processes=None):
 
 
 # ---------------------------------- Workers -------------------------------------- #
-def _spot_worker(device: dict, api: SofarApi):
+def _spot_worker(device: dict, api: None):
     """
     Worker to grab Spotter data
 
@@ -607,7 +607,7 @@ def _spot_worker(device: dict, api: SofarApi):
 
     _id = device['spotterId']
     _name = device['name']
-    _api = api
+    _api = api or SofarApi()
 
     sptr = Spotter(_id, _name, _api)
     sptr.update()

--- a/tests/test_sofar_api_class.py
+++ b/tests/test_sofar_api_class.py
@@ -1,12 +1,13 @@
 """
-This file is part of pysofar: A client for interfacing with Sofar Oceans Spotter API
+This file is part of pysofar: 
+A client for interfacing with Sofar Ocean Technologies Spotter API
 
 Contents: Tests for device endpoints
 
-Copyright (C) 2019
+Copyright (C) 2019-2023
 Sofar Ocean Technologies
 
-Authors: Mike Sosa
+Authors: Mike Sosa et al
 """
 from pysofar import wavefleet_exceptions
 from pysofar.sofar import SofarApi
@@ -112,12 +113,13 @@ def test_get_all_data():
     
 def test_get_sensor_data():
     # Test that getting sensor data in a time range works
-    spotter_id = 'SPOT-9999'
-    st = '2021-07-18'
-    end = '2021-07-19'
+    spotter_id = 'SPOT-30081D'
+    st = '2022-08-01'
+    end = '2022-08-02'
     
     dat = api.get_sensor_data(spotter_id, start_date=st, end_date=end)
     
     assert dat is not None
+    print(dat)
     assert 'sensorPosition' in dat[-1]
     

--- a/tests/test_sofar_api_class.py
+++ b/tests/test_sofar_api_class.py
@@ -24,7 +24,7 @@ def test_custom_api():
 
 
 api = SofarApi()
-latest_dat = api.get_latest_data('SPOT-0350', include_wind_data=True)
+latest_dat = api.get_latest_data('SPOT-30344R', include_wind_data=True)
 
 
 def test_get_latest_data():
@@ -42,7 +42,7 @@ def test_get_and_update_spotters():
     from pysofar.spotter import Spotter
     from pysofar.sofar import get_and_update_spotters
 
-    sptrs = get_and_update_spotters(_api=api)
+    sptrs = get_and_update_spotters(_api=api, _processes=2)
 
     assert sptrs is not None
     assert all(map(lambda x: isinstance(x, Spotter), sptrs))

--- a/tests/test_spotter_class.py
+++ b/tests/test_spotter_class.py
@@ -9,10 +9,10 @@ Sofar Ocean Technologies
 
 Authors: Mike Sosa et al
 """
+import pytest
+
 from pysofar.sofar import SofarApi
 from pysofar.spotter import Spotter
-
-import pytest
 
 api = SofarApi()
 

--- a/tests/test_spotter_class.py
+++ b/tests/test_spotter_class.py
@@ -1,23 +1,25 @@
 """
-This file is part of pysofar: A client for interfacing with Sofar Oceans Spotter API
+This file is part of pysofar: 
+A client for interfacing with Sofar Ocean Technologies Spotter API
 
 Contents: Tests for device endpoints
 
-Copyright (C) 2019
+Copyright (C) 2019-2023
 Sofar Ocean Technologies
 
-Authors: Mike Sosa
+Authors: Mike Sosa et al
 """
 from pysofar.sofar import SofarApi
 from pysofar.spotter import Spotter
 
+import pytest
+
 api = SofarApi()
 
-device = Spotter('SPOT-0350', '')
-
+device = Spotter('SPOT-30344R', '')
 
 def test_spotter_update():
-    # tests the spotter updates correctly
+    # tests the Spotter updates correctly
     device.update()
 
     assert device.mode is not None
@@ -67,18 +69,18 @@ def test_spotter_edit():
 
 
 def test_spotter_mode():
-    # test the spotter mode property is set correctly
+    # test the Spotter mode property is set correctly
     device.mode = 'track'
     assert device.mode == 'tracking'
 
     device.mode = 'full'
     assert device.mode == 'waves_spectrum'
 
-
-def test_spotter_grab_data():
-    # test spotter can correctly grab data
+@pytest.mark.xfail()
+def test_spotter_grab_data_with_limit():
+    # test Spotter can correctly grab data with limit
+    # will fail if device is not owned by the token making the request
     dat = device.grab_data(limit=20)
-    print(dat)
 
     assert 'waves' in dat
     assert len(dat['waves']) <= 20

--- a/tests/test_wave_query_class.py
+++ b/tests/test_wave_query_class.py
@@ -10,9 +10,9 @@ Authors: Mike Sosa
 """
 from pysofar.sofar import WaveDataQuery
 
-st = '2019-05-02'
-end = '2019-05-10'
-q = WaveDataQuery('SPOT-0350', limit=100, start_date=st, end_date=end)
+st = '2023-05-02'
+end = '2023-05-10'
+q = WaveDataQuery('SPOT-30344R', limit=100, start_date=st, end_date=end)
 q.wind(True)
 
 
@@ -28,7 +28,7 @@ def test_query_execute():
 
 
 def test_query_no_dates():
-    # resturned latest data first
+    # returned latest data first
     q.limit(10)
     q.clear_start_date()
     q.clear_end_date()
@@ -42,7 +42,7 @@ def test_query_no_dates():
 
 
 def test_query_no_start():
-    # resturned
+    # returned
     q.limit(10)
 
     q.clear_start_date()

--- a/tests/test_wave_query_class.py
+++ b/tests/test_wave_query_class.py
@@ -3,10 +3,10 @@ This file is part of pysofar: A client for interfacing with Sofar Oceans Spotter
 
 Contents: Tests for device endpoints
 
-Copyright (C) 2019
+Copyright (C) 2019-2023
 Sofar Ocean Technologies
 
-Authors: Mike Sosa
+Authors: Mike Sosa et al
 """
 from pysofar.sofar import WaveDataQuery
 
@@ -70,18 +70,17 @@ def test_query_no_end():
     assert 'waves' in response
     assert 'wind' in response
 
-# TODO: need to get a viable spotter for testing
-# def test_query_surface_temp():
-#     q.surface_temp(True)
-#     q.limit = 10
-#
-#     q.clear_end_date()
-#     response = q.execute()
-#     q.set_start_date(st)
-#
-#     assert response is not None
-#     assert isinstance(response, dict)
-#
-#     assert 'waves' in response
-#     assert 'wind' in response
-#     assert 'surfaceTemp' in response
+def test_query_surface_temp():
+    q.surface_temp(True)
+    q.limit = 10
+
+    q.clear_end_date()
+    response = q.execute()
+    q.set_start_date(st)
+
+    assert response is not None
+    assert isinstance(response, dict)
+
+    assert 'waves' in response
+    assert 'wind' in response
+    assert 'surfaceTemp' in response


### PR DESCRIPTION
These commits update the pysofar tests with a variety of goals:

* change the Spotter being tested most often to the one that is granted to API trial users
* open up testing of SST sensor data
* open up testing of Smart Mooring sensor data
* update copyright info
* mark one test as an expected failure

Currently, all tests except two pass, with one expected failure.  The two tests that don't pass are due to a documented difference in API responses between Spotters 'owned by' the token user versus Spotters granted read-only access via other means.