### PR TITLE
Improve token & custom token handling

### DIFF
--- a/src/pysofar/__init__.py
+++ b/src/pysofar/__init__.py
@@ -44,7 +44,7 @@ class SofarConnection:
 
     @property
     def header(self):
-        return {'token': self._token, 'Content-Type': 'application/json'}
+        return {'token': self.token, 'Content-Type': 'application/json'}
 
     # Helper methods
     def _get(self, endpoint_suffix, params: dict = None):

--- a/src/pysofar/__init__.py
+++ b/src/pysofar/__init__.py
@@ -37,7 +37,10 @@ class SofarConnection:
     def __init__(self, custom_token=None):
         self._token = custom_token or get_token()
         self.endpoint = get_endpoint()
-        self.header = {'token': self._token, 'Content-Type': 'application/json'}
+
+    @property
+    def header(self):
+        return {'token': self._token, 'Content-Type': 'application/json'}
 
     # Helper methods
     def _get(self, endpoint_suffix, params: dict = None):
@@ -62,8 +65,15 @@ class SofarConnection:
 
         return status, data
 
-    def set_token(self, new_token):
+    def _set_token(self, new_token):
         self._token = new_token
-        self.header.update({'token': new_token})
+
+    @property
+    def token(self):
+        return self._token
+
+    @token.setter
+    def token(self, value):
+        self._set_token(value)
 
 

--- a/src/pysofar/__init__.py
+++ b/src/pysofar/__init__.py
@@ -14,7 +14,11 @@ import json
 def get_token():
     # config values
     userpath = os.path.expanduser("~")
+
     environmentFile = os.path.join(userpath, 'sofar_api.env')
+    if not os.path.exists(environmentFile):
+        environmentFile = dotenv.find_dotenv()
+
     dotenv.load_dotenv(environmentFile)
     token = os.getenv('WF_API_TOKEN')
     _wavefleet_token = token

--- a/src/pysofar/spotter.py
+++ b/src/pysofar/spotter.py
@@ -294,7 +294,7 @@ class Spotter:
 
         :return: Data as a json based on the given query paramters
         """
-        _query = WaveDataQuery(self.id, limit, start_date, end_date)
+        _query = WaveDataQuery(self.id, limit, start_date, end_date, custom_token=self._session.token)
         _query.waves(include_waves)
         _query.wind(include_wind)
         _query.track(include_track)

--- a/src/pysofar/spotter.py
+++ b/src/pysofar/spotter.py
@@ -292,7 +292,7 @@ class Spotter:
                                         identified as a potentially unwanted spike.
         :param processing_sources: Optional string for which processingSources to include (embedded, hdr, all)
 
-        :return: Data as a json based on the given query paramters
+        :return: Data as a json based on the given query parameters
         """
         _query = WaveDataQuery(self.id, limit, start_date, end_date, custom_token=self._session.token)
         _query.waves(include_waves)


### PR DESCRIPTION
Fixes to token handling/usage from @pieterbartsmit —

* ensure usage of custom_token throughout `pysofar`, including workers and subclasses
* fall back to customary `.env` file if custom `sofar_api.env` file is not present

