### PR TITLE
Add cellular signal metrics to pysofar

### DIFF
--- a/src/pysofar/__init__.py
+++ b/src/pysofar/__init__.py
@@ -47,7 +47,6 @@ class SofarConnection:
             response = requests.get(url, headers=self.header, params=params)
 
         status = response.status_code
-        # data = json.loads(response.text)
         data = response.json()
 
         return status, data
@@ -57,7 +56,7 @@ class SofarConnection:
                                 json=json_data,
                                 headers=self.header)
         status = response.status_code
-        data = json.loads(response.text)
+        data = response.json()
 
         return status, data
 

--- a/src/pysofar/__init__.py
+++ b/src/pysofar/__init__.py
@@ -28,7 +28,6 @@ def get_endpoint():
         _endpoint = 'https://api.sofarocean.com/api'
     return _endpoint
 
-
 class SofarConnection:
     """
     Base Parent class for connections to the API
@@ -42,14 +41,14 @@ class SofarConnection:
     # Helper methods
     def _get(self, endpoint_suffix, params: dict = None):
         url = f"{self.endpoint}/{endpoint_suffix}"
-
         if params is None:
             response = requests.get(url, headers=self.header)
         else:
             response = requests.get(url, headers=self.header, params=params)
 
         status = response.status_code
-        data = json.loads(response.text)
+        # data = json.loads(response.text)
+        data = response.json()
 
         return status, data
 
@@ -65,5 +64,3 @@ class SofarConnection:
     def set_token(self, new_token):
         self._token = new_token
         self.header.update({'token': new_token})
-
-

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -592,7 +592,6 @@ class CellularSignalMetricsQuery(SofarUserRestQuery):
 
         :return: Data as a dictionary
         """
-        print(self._params)
         scode, data = self._get(f"devices/{self.spotter_id}/cellular-signal-metrics", params=self._params)
 
         if scode != 200:

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -15,8 +15,9 @@ from pysofar import SofarConnection
 from pysofar.tools import parse_date
 from pysofar.wavefleet_exceptions import QueryError
 from typing import List, Tuple, Dict
-import warnings
 
+import os
+import warnings
 
 class SofarApi(SofarConnection):
     """
@@ -366,7 +367,8 @@ class WaveDataQuery(SofarConnection):
 
     def execute(self):
         """
-        Calls the api wave-data endpoint and if successful returns the queried data with the set query parameters
+        Calls the api wave-data endpoint.
+        If successful, returns the queried data with the set query parameters
 
         :return: Data as a dictionary
         """
@@ -536,6 +538,56 @@ class WaveDataQuery(SofarConnection):
 
         return s
 
+class SofarUserRestQuery(SofarConnection):
+    """
+    I represent a query against the /user-rest endpoint
+    """
+    @classmethod
+    def get_user_rest_endpoint(cls):
+        _endpoint = os.getenv('WF_USER_REST_URL')
+        if _endpoint is None:
+            _endpoint = 'https://api.sofarocean.com/user-rest'
+        return _endpoint
+
+    def __init__(self, custom_token=None):
+        super().__init__(custom_token)
+        self.endpoint = self.get_user_rest_endpoint()
+
+class CellularSignalMetricsQuery(SofarUserRestQuery):
+    """
+    I represent a query against the cellular-signal-metrics endpoint
+    """
+    _MISSING = object()
+
+    def __init__(self,
+            spotter_id: str,
+            limit: int = 20,
+            # start_epoch=_MISSING,
+            # end_epoch=_MISSING,
+            params=None):
+        super().__init__()
+        self.spotter_id = spotter_id
+        self._limit = limit
+        self._params = {
+            'spotterId': spotter_id,
+            'limit': limit,
+        }
+        if params:
+            self._params.update(params)
+
+    def execute(self):
+        """
+        Calls the cellular-signal-metrics endpoint.
+        If successful, returns the queried data with the set query parameters.
+        
+        :return: Data as a dictionary
+        """
+        scode, data = self._get(f"devices/{self.spotter_id}/cellular-signal-metrics", params=self._params)
+
+        if scode != 200:
+            raise QueryError(data['message'])
+
+        return data['data']
 
 # ---------------------------------- Util Functions -------------------------------------- #
 def get_and_update_spotters(_api=None):

--- a/src/pysofar/sofar.py
+++ b/src/pysofar/sofar.py
@@ -562,32 +562,43 @@ class CellularSignalMetricsQuery(SofarUserRestQuery):
     def __init__(self,
             spotter_id: str,
             limit: int = 20,
-            # start_epoch=_MISSING,
-            # end_epoch=_MISSING,
+            order_ascending: bool = False,
+            start_epoch_ms=_MISSING,
+            end_epoch_ms=_MISSING,
             params=None):
         super().__init__()
         self.spotter_id = spotter_id
         self._limit = limit
         self._params = {
-            'spotterId': spotter_id,
-            'limit': limit,
+            'spotterId'      : spotter_id,
+            'limit'          : limit,
+            'order_ascending': str(order_ascending).lower(),
         }
         if params:
             self._params.update(params)
 
-    def execute(self):
+        if start_epoch_ms and start_epoch_ms is not self._MISSING:
+            self._params.update({'since_epoch_ms': str(start_epoch_ms)})
+
+        if end_epoch_ms and end_epoch_ms is not self._MISSING:
+            self._params.update({'before_epoch_ms': str(end_epoch_ms)})
+
+    def execute(self, return_raw = False):
         """
         Calls the cellular-signal-metrics endpoint.
         If successful, returns the queried data with the set query parameters.
         
+        if return_raw is True, return the outer metadata structure of the response
+
         :return: Data as a dictionary
         """
+        print(self._params)
         scode, data = self._get(f"devices/{self.spotter_id}/cellular-signal-metrics", params=self._params)
 
         if scode != 200:
             raise QueryError(data['message'])
 
-        return data['data']
+        return data if return_raw else data['data']
 
 # ---------------------------------- Util Functions -------------------------------------- #
 def get_and_update_spotters(_api=None):

--- a/src/pysofar/spotter.py
+++ b/src/pysofar/spotter.py
@@ -8,7 +8,7 @@ Sofar Ocean Technologies
 
 Authors: Mike Sosa et al.
 """
-from pysofar.sofar import SofarApi, WaveDataQuery
+from pysofar.sofar import SofarApi, WaveDataQuery, CellularSignalMetricsQuery
 
 
 # --------------------- Devices ----------------------------------------------#
@@ -292,7 +292,7 @@ class Spotter:
                                         identified as a potentially unwanted spike.
         :param processing_sources: Optional string for which processingSources to include (embedded, hdr, all)
 
-        :return: Data as a json based on the given query paramters
+        :return: Data as a json based on the given query parameters
         """
         _query = WaveDataQuery(self.id, limit, start_date, end_date)
         _query.waves(include_waves)
@@ -314,3 +314,31 @@ class Spotter:
         _data = _query.execute()
 
         return _data
+
+    def grab_cellular_signal_metrics(self, 
+        limit: int = 20,
+        order_ascending: bool = False,
+        start_epoch_ms: int = None,
+        end_epoch_ms: int = None):
+        """
+        Grabs and returns the cellular signal metrics (if available) for the given Spotter
+
+        :param limit: The limit for data to grab. Defaults to 20.
+        :param order_ascending: Return results in ascending order?
+        :param start_epoch_ms: Optional UTC epoch time (integer) at which to begin finding results
+        :param end_epoch_ms: Optional UTC epoch time (integer) at which to end finding results
+
+        :return: Data as a json based on the given query parameters
+        """
+
+        _query = CellularSignalMetricsQuery(
+            self.id,
+            limit=limit,
+            order_ascending=order_ascending,
+            start_epoch_ms=start_epoch_ms,
+            end_epoch_ms=end_epoch_ms,
+        )
+        _data = _query.execute()
+
+        return _data
+

--- a/tests/test_sofar_api_device_endpoints.py
+++ b/tests/test_sofar_api_device_endpoints.py
@@ -1,5 +1,5 @@
 """
-This file is part of pysofar: A client for interfacing with Sofar Oceans Spotter API
+This file is part of pysofar: A client for interfacing with Sofar Ocean's Spotter API
 
 Contents: Tests for device endpoints
 

--- a/tests/test_sofar_api_user_rest_cellular.py
+++ b/tests/test_sofar_api_user_rest_cellular.py
@@ -34,7 +34,7 @@ class UserRestDevicesTest(unittest.TestCase):
         """
         Guess that a Spotter ending in C might be a cellular Spotter
         
-        This is /not/ the best way of doing this.[A
+        This is /not/ the best way of doing this.
         """
         return next((spot_id for spot_id in self._device_ids if spot_id.endswith('C')), None)
         

--- a/tests/test_sofar_api_user_rest_cellular.py
+++ b/tests/test_sofar_api_user_rest_cellular.py
@@ -62,7 +62,6 @@ class UserRestDevicesTest(unittest.TestCase):
 
         query = CellularSignalMetricsQuery(self._cellular_id)
         data = query.execute()
-        # print(json.dumps(data[0], indent=2))
 
     def setUp(self):
         self._api = SofarApi()

--- a/tests/test_sofar_api_user_rest_cellular.py
+++ b/tests/test_sofar_api_user_rest_cellular.py
@@ -1,0 +1,40 @@
+"""
+This file is part of pysofar: A client for interfacing with Sofar Ocean's Spotter API
+
+Contents: Tests for user-rest/cellular-signal-metrics endpoint
+
+Copyright (C) 2024
+Sofar Ocean Technologies
+
+Authors: Tim Johnson
+"""
+import json
+import unittest
+
+from pysofar.sofar import SofarApi, CellularSignalMetricsQuery
+
+class UserRestDevicesTest(unittest.TestCase):
+
+    def testCellularSignalMetricsRequest(self):
+        if not self._cellular_id:
+            self.skipTest("could not find a likely cellular Spotter")
+
+        query = CellularSignalMetricsQuery(self._cellular_id)
+        data = query.execute()
+        print(json.dumps(data[0], indent=2))
+
+    def setUp(self):
+        self._api = SofarApi()
+        # dat = api.get_device_location_data()
+        self._devices = self._api.devices
+        self._device_ids = self._api.device_ids
+        self._cellular_id = self._findPossibleCellularDevice()
+
+    def _findPossibleCellularDevice(self):
+        """
+        Guess that a Spotter ending in C might be a cellular Spotter
+        
+        This is /not/ the best way of doing this.[A
+        """
+        return next((spot_id for spot_id in self._device_ids if spot_id.endswith('C')), None)
+        

--- a/tests/test_sofar_api_user_rest_cellular.py
+++ b/tests/test_sofar_api_user_rest_cellular.py
@@ -12,8 +12,13 @@ import json
 import unittest
 
 from pysofar.sofar import SofarApi, CellularSignalMetricsQuery
+from pysofar.spotter import Spotter
 
 class UserRestDevicesTest(unittest.TestCase):
+    def testCellularSignalMetricsFromSpotter(self):
+        spot = Spotter(self._cellular_id, self._cellular_id)
+        data = spot.grab_cellular_signal_metrics()
+        self.assertTrue(data)
 
     def testCellularSignalMetricsParameters(self):
         if not self._cellular_id:
@@ -57,11 +62,10 @@ class UserRestDevicesTest(unittest.TestCase):
 
         query = CellularSignalMetricsQuery(self._cellular_id)
         data = query.execute()
-        print(json.dumps(data[0], indent=2))
+        # print(json.dumps(data[0], indent=2))
 
     def setUp(self):
         self._api = SofarApi()
-        # dat = api.get_device_location_data()
         self._devices = self._api.devices
         self._device_ids = self._api.device_ids
         self._cellular_id = self._findPossibleCellularDevice()

--- a/tests/test_sofar_api_user_rest_cellular.py
+++ b/tests/test_sofar_api_user_rest_cellular.py
@@ -15,6 +15,42 @@ from pysofar.sofar import SofarApi, CellularSignalMetricsQuery
 
 class UserRestDevicesTest(unittest.TestCase):
 
+    def testCellularSignalMetricsParameters(self):
+        if not self._cellular_id:
+            self.skipTest("could not find a likely cellular Spotter")
+        my_limit = 30
+        my_start_epoch_ms=1727488168
+        my_end_epoch_ms=1727995013
+        my_order = True
+
+        query = CellularSignalMetricsQuery(
+            self._cellular_id,
+            limit=my_limit,
+            order_ascending=my_order,            
+            start_epoch_ms=my_start_epoch_ms,
+            end_epoch_ms=my_end_epoch_ms,
+        )
+        data = query.execute(return_raw=True)
+        self.assertIn('options', data)
+        # the API response feeds us back the options we gave it,
+        # but in the case of this API, the response keys are different
+        # from the request parameter keys.
+        # sc-208038
+        options = data['options']
+        self.assertEqual(options['spotterId'], self._cellular_id)
+        self.assertEqual(options['limit'], my_limit)
+        self.assertNotIn('order_ascending', options)
+        self.assertIn('orderAscending', options)
+        self.assertEqual(options['orderAscending'], True)
+        self.assertIn('startEpochMs', options)   #  !! unexpected
+        self.assertIn('endEpochMs', options)     #  !! unexpected
+        self.assertIsNone(options['startEpochMs'])
+        self.assertIsNone(options['endEpochMs'])
+        self.assertIn('sinceEpochMs', options)
+        self.assertIn('beforeEpochMs', options)
+        self.assertEqual(options['sinceEpochMs'], my_start_epoch_ms)
+        self.assertEqual(options['beforeEpochMs'], my_end_epoch_ms)
+
     def testCellularSignalMetricsRequest(self):
         if not self._cellular_id:
             self.skipTest("could not find a likely cellular Spotter")
@@ -37,4 +73,3 @@ class UserRestDevicesTest(unittest.TestCase):
         This is /not/ the best way of doing this.
         """
         return next((spot_id for spot_id in self._device_ids if spot_id.endswith('C')), None)
-        


### PR DESCRIPTION
Add support for the cellular signal metrics API endpoint to pysofar.  This can be accessed via the Spotter object method `grab_cellular_signal_metrics()`.

This allows API users to fetch the cellular signal metrics for their systems.
